### PR TITLE
fetch method to IpaReader::IpaFile & modify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ irb > ipa_file.icon_prerendered
  => false
 ```
 
+### fetch key value
+
+```
+#ipa_file fetch key
+ipa_file.fecth "CFBundleShortVersionString"
+ => "1.0.0" 
+```
+
 ## INSTALL
 
 `gem install ipa_reader`

--- a/lib/ipa_reader/ipa_file.rb
+++ b/lib/ipa_reader/ipa_file.rb
@@ -15,7 +15,12 @@ module IpaReader
       cf_plist = CFPropertyList::List.new(:data => self.read_file(/\/Info.plist/), :format => CFPropertyList::List::FORMAT_BINARY)
       self.plist = cf_plist.value.to_rb
     end
-    
+
+    def fetch key=nil
+      raise "dont foud the key nil value" if key.nil?
+      plist[key]
+    end
+
     def version
       plist["CFBundleVersion"]
     end


### PR DESCRIPTION
When I want to get other data from info.plist file, IpaReader::IpaFile dont get the data, because now only can get version or name or target_os_version etc.
So, new fetch key method, can fetch the key u value want to, if the key inexistence, return nil
